### PR TITLE
Use scala for Authorization headers instead of curl

### DIFF
--- a/cli/src/test/scala/libhttpsimple/Base64Test.scala
+++ b/cli/src/test/scala/libhttpsimple/Base64Test.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package libhttpsimple
+
+import utest._
+
+// FIXME scala native doesn't seem to like tests in two different projects in the
+// FIXME same build so it throws a [error] (cli/nativetest:nativeLinkNIR) java.nio.file.FileSystemAlreadyExistsException
+
+object Base64Test extends TestSuite {
+  val tests = this{
+    "Encode Strings to base64" - {
+      val tests = Map(
+        "abc" -> "YWJj",
+        "test" -> "dGVzdA==",
+        "a" -> "YQ==",
+        "ab" -> "YWI=",
+        "abc" -> "YWJj",
+        "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWjAxMjM0" -> "WVdKalpHVm1aMmhwYW10c2JXNXZjSEZ5YzNSMWRuZDRlWHBCUWtORVJVWkhTRWxLUzB4TlRrOVFVVkpUVkZWV1YxaFpXakF4TWpNMA==")
+
+      tests.foreach {
+        case (in, out) =>
+          val encoded = Base64Encoder(in)
+
+          assert(encoded == out)
+      }
+    }
+  }
+}

--- a/libhttpsimple-bindings/src/main/scala/libhttpsimple/Base64Encoder.scala
+++ b/libhttpsimple-bindings/src/main/scala/libhttpsimple/Base64Encoder.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Lightbend, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package libhttpsimple
+
+object Base64Encoder {
+  private val charSet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+
+  /**
+   * Inspired by https://en.wikibooks.org/wiki/Algorithm_Implementation/Miscellaneous/Base64#Java
+   */
+  def apply(in: String): String = {
+    val charsToPad =
+      if (in.length % 3 == 0)
+        0
+      else
+        3 - (in.length % 3)
+
+    val data = in + ("\u0000" * charsToPad)
+    val rightPad = "=" * charsToPad
+    val builder = new StringBuilder
+
+    var i = 0
+
+    while (i < data.length) {
+      val n = (data.charAt(i) << 16) + (data.charAt(i + 1) << 8) + data.charAt(i + 2)
+
+      builder.append(charSet.charAt((n >> 18) & 63))
+      builder.append(charSet.charAt((n >> 12) & 63))
+      builder.append(charSet.charAt((n >> 6) & 63))
+      builder.append(charSet.charAt(n & 63))
+
+      i += 3
+    }
+
+    builder.substring(0, builder.length - rightPad.length) + rightPad
+  }
+}

--- a/libhttpsimple-bindings/src/main/scala/libhttpsimple/nativebinding/httpsimple.scala
+++ b/libhttpsimple-bindings/src/main/scala/libhttpsimple/nativebinding/httpsimple.scala
@@ -26,7 +26,7 @@ object httpsimple {
 
   def global_init(): CInt = native.extern
   def global_cleanup(): Unit = native.extern
-  def do_http(validate_tls: CLong, tls_cacerts_path: CString, http_method: CString, url: CString, request_headers_raw: CString, auth_type: CString, auth_value: CString, request_body: CString): Ptr[http_response] = native.extern
+  def do_http(validate_tls: CLong, tls_cacerts_path: CString, http_method: CString, url: CString, request_headers_raw: CString, request_body: CString): Ptr[http_response] = native.extern
   def get_error_code(http_response: Ptr[http_response]): CLong = native.extern
   def get_error_message(http_response: Ptr[http_response]): CString = native.extern
   def get_http_status(http_response: Ptr[http_response]): CLong = native.extern

--- a/libhttpsimple/src/main/c/httpsimple.c
+++ b/libhttpsimple/src/main/c/httpsimple.c
@@ -51,7 +51,7 @@ size_t writefunc(void *ptr, size_t size, size_t nmemb, struct http_response *s)
   return size * nmemb;
 }
 
-struct http_response *do_http(long validate_tls, char *tls_cacerts_path, char *http_method, char *url, char *request_headers_raw, char *auth_type, char *auth_value, char *request_body) {
+struct http_response *do_http(long validate_tls, char *tls_cacerts_path, char *http_method, char *url, char *request_headers_raw, char *request_body) {
   CURL *curl;
   CURLcode res_curl_code;
   struct http_response *s = malloc(sizeof(struct http_response));
@@ -71,15 +71,6 @@ struct http_response *do_http(long validate_tls, char *tls_cacerts_path, char *h
 
       if (tls_cacerts_path && strlen(tls_cacerts_path) > 0) {
         curl_easy_setopt(curl, CURLOPT_CAINFO, tls_cacerts_path);
-      }
-
-      if (auth_type && strlen(auth_type) > 0 &&
-            auth_value && strlen(auth_value) > 0) {
-        if (strcmp("basic", auth_type) == 0) {
-            curl_easy_setopt(curl, CURLOPT_USERPWD, auth_value);
-        } else if (strcmp(auth_type, "bearer")) {
-            curl_easy_setopt(curl, CURLOPT_XOAUTH2_BEARER, auth_value);
-        }
       }
 
       // Append request headers if defined

--- a/libhttpsimple/src/main/c/httpsimple.h
+++ b/libhttpsimple/src/main/c/httpsimple.h
@@ -27,7 +27,7 @@ extern int global_init();
 
 extern void global_cleanup();
 
-extern struct http_response *do_http(long validate_tls, char *tls_cacerts_path, char *http_method, char *url, char *request_headers_raw, char *auth_type, char *auth_value, char *request_body);
+extern struct http_response *do_http(long validate_tls, char *tls_cacerts_path, char *http_method, char *url, char *request_headers_raw, char *request_body);
 
 extern long get_error_code(struct http_response *s);
 


### PR DESCRIPTION
This PR adds a tiny base64 implementation for `Authorization` headers so that all headers can be assembled in Scala and keeps `libhttpsimple` fairly simple. I think it could use more tests in the `Base64Test`.

This would work quite nicely as `java.util.Base64` is bound to land in Scala Native so when it does we can just rip this out.

The risk is that base64 could be broken in some cases, but I think we're running the risk of bugs by using Scala Native in the first place. Best thing to do would be to build out the test cases.